### PR TITLE
Script wasn't reading the debug status.

### DIFF
--- a/views/helpers/cf.php
+++ b/views/helpers/cf.php
@@ -72,7 +72,8 @@ class CfHelper extends AppHelper {
  * Are we forcing the timestamp (based on core.php setting)?
  * (We really, really should)
  */   
-  public function beforeRender() {
+  public function beforeRender($viewFile) {
+    parent::beforeRender($viewFile);
     if ((Configure::read('Asset.timestamp') == true && Configure::read() > 0) || Configure::read('Asset.timestamp') === 'force') {
       $this->forceTimestamp = TRUE;
     }

--- a/views/helpers/cf.php
+++ b/views/helpers/cf.php
@@ -107,7 +107,7 @@ class CfHelper extends AppHelper {
  * Works for arrays of assets (like with JS or CSS) or single files
  */  
   private function setAssetPath($assets = NULL) {
-    if($assets && Configure::read() == 0) {
+    if($assets && Configure::read('debug') == 0) {
       if(is_array($assets)) {
         for($i = 0; $i < count($assets); $i++) {
           $assets[$i] = $this->pathPrep() . $assets[$i] . $this->getAssetTimestamp(); 


### PR DESCRIPTION
Script wasn't reading the debug status meaning that it behaved in exactly the same way (reading files locally) regardless of whether debug was set to zero or higher.
